### PR TITLE
Add Password Reset Page and Fix Misspellings

### DIFF
--- a/src/layouts/partials/Header.astro
+++ b/src/layouts/partials/Header.astro
@@ -111,13 +111,11 @@ const { pathname } = Astro.url;
         ))
       }
       <li class="nav-item mt-2 lg:hidden">
-        <a class="btn btn-white btn-sm border-border" href="/signin">
-          Sing Up Now</a
-        >
+        <a class="btn btn-white btn-sm border-border" href="/signin">Sign In</a>
       </li>
     </ul>
     <div class="order-1 ml-auto hidden items-center md:order-2 md:ml-0 lg:flex">
-      <a class="btn btn-white btn-sm" href="/signin"> Sing Up Now</a>
+      <a class="btn btn-white btn-sm" href="/signin"> Sign In</a>
     </div>
   </nav>
 </header>

--- a/src/pages/password-reset.astro
+++ b/src/pages/password-reset.astro
@@ -1,0 +1,45 @@
+---
+import Base from "@/layouts/Base.astro";
+import SigninSlider from "@/layouts/function-components/SigninSlider.jsx";
+---
+
+<Base>
+  <section>
+    <div class="container max-w-full">
+      <div class="row">
+        <div class="min-h-[980px] bg-white py-10 lg:col-6 lg:py-[114px]">
+          <div class="mx-auto w-full max-w-[480px]">
+            <img class="mb-8" src="/images/flower.png" alt="" />
+            <h1 class="mb-4">Password Reset</h1>
+            <p>Enter the email address for your account to request a password reset. An email will be sent to the email address on your account with a reset link.</p>
+            <form action="#">
+              <div class="form-group">
+                <label for="email" class="form-label">Email Address</label>
+                <input
+                  type="email"
+                  id="email"
+                  class="form-control"
+                  placeholder="Your Email Address"
+                />
+              </div>
+              <input
+                class="btn btn-primary mt-10 block w-full"
+                type="submit"
+                value="Reset Password"
+              />
+              <p class="mt-6 text-center">
+                Don't have an account?
+                <a class="text-dark" href="/signup">Sign up</a> to create one.
+                <br/>Or <a class="text-dark" href="/signin">Sign in</a> to your account.
+              </p>
+            </form>
+          </div>
+        </div>
+        <SigninSlider
+          client:load
+          title="Make all your dreams<br/>come true"
+        />
+      </div>
+    </div>
+  </section>
+</Base>

--- a/src/pages/signin.astro
+++ b/src/pages/signin.astro
@@ -10,7 +10,7 @@ import SigninSlider from "@/layouts/function-components/SigninSlider.jsx";
         <div class="min-h-[980px] bg-white py-10 lg:col-6 lg:py-[114px]">
           <div class="mx-auto w-full max-w-[480px]">
             <img class="mb-8" src="/images/flower.png" alt="" />
-            <h1 class="mb-4">Sing In</h1>
+            <h1 class="mb-4">Sign In</h1>
             <p>Donec sollicitudin molestie malesda sollitudin</p>
             <div class="signin-options mt-10">
               <a class="btn btn-outline-white block w-full text-dark" href="#"
@@ -27,7 +27,7 @@ import SigninSlider from "@/layouts/function-components/SigninSlider.jsx";
 
             <form action="#">
               <div class="form-group">
-                <label for="email" class="form-label">Email Adrdess</label>
+                <label for="email" class="form-label">Email Address</label>
                 <input
                   type="email"
                   id="email"
@@ -50,15 +50,16 @@ import SigninSlider from "@/layouts/function-components/SigninSlider.jsx";
                 value="Sign In"
               />
               <p class="mt-6 text-center">
-                Can't <a class="text-dark">log in</a>?
-                <a class="text-dark" href="/signup">Sign up</a> for create account
+                Trouble signing in?
+                <a class="text-dark" href="/password-reset">Reset your password</a>.
+                <br/>Or <a class="text-dark" href="/signup">Sign up</a> to create an account.
               </p>
             </form>
           </div>
         </div>
         <SigninSlider
           client:load
-          title=" Turn your All ideas into<br /> your reality"
+          title="Turn your All ideas into<br /> your reality"
         />
       </div>
     </div>

--- a/src/pages/signup.astro
+++ b/src/pages/signup.astro
@@ -10,7 +10,7 @@ import SigninSlider from "@/layouts/function-components/SigninSlider.jsx";
         <div class="min-h-[980px] bg-white py-10 lg:col-6 lg:py-[114px]">
           <div class="mx-auto w-full max-w-[480px]">
             <img class="mb-8" src="/images/flower.png" alt="" />
-            <h1 class="mb-4">Sing Up</h1>
+            <h1 class="mb-4">Sign Up</h1>
             <p>Donec sollicitudin molestie malesda sollitudin</p>
             <div class="signin-options mt-10">
               <a class="btn btn-outline-white block w-full text-dark" href="#"
@@ -36,7 +36,7 @@ import SigninSlider from "@/layouts/function-components/SigninSlider.jsx";
                 />
               </div>
               <div class="form-group mt-4">
-                <label for="email" class="form-label">Email Adrdess</label>
+                <label for="email" class="form-label">Email Address</label>
                 <input
                   type="email"
                   id="email"
@@ -59,7 +59,11 @@ import SigninSlider from "@/layouts/function-components/SigninSlider.jsx";
                 value="Sign Up"
               />
             </form>
-          </div>
+            <p class="mt-6 text-center">
+              Already have an account?
+              <a class="text-dark" href="/signin">Sign in</a>.
+            </p>
+        </div>
         </div>
         <SigninSlider
           client:load


### PR DESCRIPTION
1. Added a _password-reset.astro_ page, adding it to the links at the bottom of _signin_ and _signup_.
2. Subtly changed the wording at the bottom of the login-related pages to include the new password reset page.
3. Fixed misspellings where 'sing' instead of 'sign' was used on main button and login-related pages.
4. Fixed misspellings of 'address' on login-related pages.